### PR TITLE
Fix getRawTransaction bug

### DIFF
--- a/bitcoind.go
+++ b/bitcoind.go
@@ -278,7 +278,7 @@ func (b *Bitcoind) GetRawTransaction(txId string, verbose bool) (rawTx interface
 	if verbose {
 		intVerbose = 1
 	}
-	r, err := b.client.call("getrawtransaction", []interface{}{txId, verbose})
+	r, err := b.client.call("getrawtransaction", []interface{}{txId, intVerbose})
 	if err = handleError(err, &r); err != nil {
 		return
 	}

--- a/bitcoind.go
+++ b/bitcoind.go
@@ -274,6 +274,10 @@ func (b *Bitcoind) GetRawMempool() (txId []string, err error) {
 
 // GetRawTransaction returns raw transaction representation for given transaction id.
 func (b *Bitcoind) GetRawTransaction(txId string, verbose bool) (rawTx interface{}, err error) {
+	intVerbose := 0
+	if verbose {
+		intVerbose = 1
+	}
 	r, err := b.client.call("getrawtransaction", []interface{}{txId, verbose})
 	if err = handleError(err, &r); err != nil {
 		return


### PR DESCRIPTION
catch HTTP error: 500 Internal Server Error
when verbose is bool type
but set to int it will be fine

testing in testnet:
>$ curl --user becent --data-binary '{"method":"getrawtransaction","params":["bf4f76cd56fe57357a7c7318a6034f9e16e3a8aea7987b854e6cac07fbbe7e2c",true],"id":1535338013830435386,"jsonrpc":"1.0"}' -H 'content-type: text/plain;' http://127.0.0.1:8332/
Enter host password for user 'becent':
{"result":null,"error":{"code":-1,"message":"JSON value is not an integer as expected"},"id":1535338013830435386}
>$ curl --user becent --data-binary '{"method":"getrawtransaction","params":["bf4f76cd56fe57357a7c7318a6034f9e16e3a8aea7987b854e6cac07fbbe7e2c",1],"id":1535338013830435386,"jsonrpc":"1.0"}' -H 'content-type: text/plain;' http://127.0.0.1:8332/
Enter host password for user 'becent':
{"result":{"hex":"010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff2403ba831504ff53835b081fffffdb2b6602000d2ff09fa498f09f988e204d722e204d6f2f00000000020000000000000000266a24aa21a9eddf3fc6f64b4da6b337373c2815653cd023857282b3a9a07f0b91e511e3357b82d314f45b000000001976a91448b5c6986b7bc6390bd1cc416154d1874fe116fd88ac0120000000000000000000000000000000000000000000000000000000000000000000000000","txid":"bf4f76cd56fe57357a7c7318a6034f9e16e3a8aea7987b854e6cac07fbbe7e2c","hash":"26f5a9a0b87019a7e78d3980e9c8c131d34100ede6bb5d16fd5c52a0277566c3","size":204,"vsize":177,"version":1,"locktime":0,"vin":[{"coinbase":"03ba831504ff53835b081fffffdb2b6602000d2ff09fa498f09f988e204d722e204d6f2f","txinwitness":["0000000000000000000000000000000000000000000000000000000000000000"],"sequence":0}],"vout":[{"value":0.00000000,"n":0,"scriptPubKey":{"asm":"OP_RETURN aa21a9eddf3fc6f64b4da6b337373c2815653cd023857282b3a9a07f0b91e511e3357b82","hex":"6a24aa21a9eddf3fc6f64b4da6b337373c2815653cd023857282b3a9a07f0b91e511e3357b82","type":"nulldata"}},{"value":15.42722771,"n":1,"scriptPubKey":{"asm":"OP_DUP OP_HASH160 48b5c6986b7bc6390bd1cc416154d1874fe116fd OP_EQUALVERIFY OP_CHECKSIG","hex":"76a91448b5c6986b7bc6390bd1cc416154d1874fe116fd88ac","reqSigs":1,"type":"pubkeyhash","addresses":["mn9QhsFiX2eEXtF6zrGn5N49iS8BHXFjBt"]}}],"blockhash":"00000000000000c84b3dce61c59e6ae59c0300f01b5ae1b715e24c872fa41ec8","confirmations":17,"time":1535333374,"blocktime":1535333374},"error":null,"id":1535338013830435386}