### PR TITLE
Add variable timeout

### DIFF
--- a/bitcoind.go
+++ b/bitcoind.go
@@ -11,6 +11,8 @@ import (
 const (
 	// VERSION represents bicoind package version
 	VERSION = 0.1
+	// DEFAULT_RPCCLIENT_TIMEOUT represent http timeout for rcp client
+	RPCCLIENT_TIMEOUT = 30
 )
 
 // A Bitcoind represents a Bitcoind client
@@ -19,7 +21,13 @@ type Bitcoind struct {
 }
 
 // New return a new bitcoind
-func New(host string, port int, user, passwd string, useSSL bool, timeout int64) (*Bitcoind, error) {
+func New(host string, port int, user, passwd string, useSSL bool, timeoutParam ...int) (*Bitcoind, error) {
+	var timeout int = RPCCLIENT_TIMEOUT
+	// If the timeout is specified in timeoutParam, allow it. 
+	if len[timeoutParam] != 0 {
+		timeout = timeoutParam[0]
+	}
+
 	rpcClient, err := newClient(host, port, user, passwd, useSSL, timeout)
 	if err != nil {
 		return nil, err

--- a/bitcoind.go
+++ b/bitcoind.go
@@ -11,8 +11,6 @@ import (
 const (
 	// VERSION represents bicoind package version
 	VERSION = 0.1
-	// DEFAULT_RPCCLIENT_TIMEOUT represent http timeout for rcp client
-	RPCCLIENT_TIMEOUT = 30
 )
 
 // A Bitcoind represents a Bitcoind client
@@ -21,8 +19,8 @@ type Bitcoind struct {
 }
 
 // New return a new bitcoind
-func New(host string, port int, user, passwd string, useSSL bool) (*Bitcoind, error) {
-	rpcClient, err := newClient(host, port, user, passwd, useSSL)
+func New(host string, port int, user, passwd string, useSSL bool, timeout int64) (*Bitcoind, error) {
+	rpcClient, err := newClient(host, port, user, passwd, useSSL, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/bitcoind.go
+++ b/bitcoind.go
@@ -24,7 +24,7 @@ type Bitcoind struct {
 func New(host string, port int, user, passwd string, useSSL bool, timeoutParam ...int) (*Bitcoind, error) {
 	var timeout int = RPCCLIENT_TIMEOUT
 	// If the timeout is specified in timeoutParam, allow it. 
-	if len[timeoutParam] != 0 {
+	if len(timeoutParam) != 0 {
 		timeout = timeoutParam[0]
 	}
 

--- a/rpcClient.go
+++ b/rpcClient.go
@@ -17,6 +17,7 @@ type rpcClient struct {
 	user       string
 	passwd     string
 	httpClient *http.Client
+	timeout    int64
 }
 
 // rpcRequest represent a RCP request
@@ -39,7 +40,7 @@ type rpcResponse struct {
 	Err    interface{}     `json:"error"`
 }
 
-func newClient(host string, port int, user, passwd string, useSSL bool) (c *rpcClient, err error) {
+func newClient(host string, port int, user, passwd string, useSSL bool, time int64) (c *rpcClient, err error) {
 	if len(host) == 0 {
 		err = errors.New("Bad call missing argument host")
 		return
@@ -82,7 +83,7 @@ func (c *rpcClient) doTimeoutRequest(timer *time.Timer, req *http.Request) (*htt
 
 // call prepare & exec the request
 func (c *rpcClient) call(method string, params interface{}) (rr rpcResponse, err error) {
-	connectTimer := time.NewTimer(RPCCLIENT_TIMEOUT * time.Second)
+	connectTimer := time.NewTimer(time.Duration(c.timeout) * time.Second)
 	rpcR := rpcRequest{method, params, time.Now().UnixNano(), "1.0"}
 	payloadBuffer := &bytes.Buffer{}
 	jsonEncoder := json.NewEncoder(payloadBuffer)

--- a/rpcClient.go
+++ b/rpcClient.go
@@ -17,7 +17,7 @@ type rpcClient struct {
 	user       string
 	passwd     string
 	httpClient *http.Client
-	timeout    int64
+	timeout    int
 }
 
 // rpcRequest represent a RCP request
@@ -40,7 +40,7 @@ type rpcResponse struct {
 	Err    interface{}     `json:"error"`
 }
 
-func newClient(host string, port int, user, passwd string, useSSL bool, time int64) (c *rpcClient, err error) {
+func newClient(host string, port int, user, passwd string, useSSL bool, timeout int) (c *rpcClient, err error) {
 	if len(host) == 0 {
 		err = errors.New("Bad call missing argument host")
 		return
@@ -57,7 +57,7 @@ func newClient(host string, port int, user, passwd string, useSSL bool, time int
 		serverAddr = "http://"
 		httpClient = &http.Client{}
 	}
-	c = &rpcClient{serverAddr: fmt.Sprintf("%s%s:%d", serverAddr, host, port), user: user, passwd: passwd, httpClient: httpClient}
+	c = &rpcClient{serverAddr: fmt.Sprintf("%s%s:%d", serverAddr, host, port), user: user, passwd: passwd, httpClient: httpClient, timeout: timeout}
 	return
 }
 

--- a/rpcClient_test.go
+++ b/rpcClient_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("RpcClient", func() {
 	Describe("Initialise a new rpcClient", func() {
 		Context("when initialisation succeeded", func() {
-			client, err := newClient("127.0.0.1", 8334, "user", "paswd", false, 600)
+			client, err := newClient("127.0.0.1", 8334, "user", "paswd", false, 30)
 			It("err should be nil", func() {
 				Expect(err).To(BeNil())
 			})
@@ -35,9 +35,9 @@ var _ = Describe("RpcClient", func() {
 		})
 	})
 
-	Describe("Do resquests", func() {
+	Describe("Do requests", func() {
 		Context("When connexion fail", func() {
-			client, err := newClient("127.0.0.1", 123, "fake", "fake", false, 600)
+			client, err := newClient("127.0.0.1", 123, "fake", "fake", false, 30)
 			_, err = client.call("getdifficulty", nil)
 			It("err should occured", func() {
 				Expect(err).Should(MatchError("Post http://127.0.0.1:123: dial tcp 127.0.0.1:123: connection refused"))
@@ -53,7 +53,7 @@ var _ = Describe("RpcClient", func() {
 			p := strings.Split(ts.URL, ":")
 			host := p[1][2:]
 			port, err := strconv.ParseInt(p[2], 10, 64)
-			client, err := newClient(host, int(port), "fake", "fake", false, 600)
+			client, err := newClient(host, int(port), "fake", "fake", false, 30)
 			_, err = client.call("getdifficulty", nil)
 
 			It("timeout err should occured", func() {

--- a/rpcClient_test.go
+++ b/rpcClient_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("RpcClient", func() {
 	Describe("Initialise a new rpcClient", func() {
 		Context("when initialisation succeeded", func() {
-			client, err := newClient("127.0.0.1", 8334, "user", "paswd", false)
+			client, err := newClient("127.0.0.1", 8334, "user", "paswd", false, 600)
 			It("err should be nil", func() {
 				Expect(err).To(BeNil())
 			})
@@ -37,7 +37,7 @@ var _ = Describe("RpcClient", func() {
 
 	Describe("Do resquests", func() {
 		Context("When connexion fail", func() {
-			client, err := newClient("127.0.0.1", 123, "fake", "fake", false)
+			client, err := newClient("127.0.0.1", 123, "fake", "fake", false, 600)
 			_, err = client.call("getdifficulty", nil)
 			It("err should occured", func() {
 				Expect(err).Should(MatchError("Post http://127.0.0.1:123: dial tcp 127.0.0.1:123: connection refused"))
@@ -53,7 +53,7 @@ var _ = Describe("RpcClient", func() {
 			p := strings.Split(ts.URL, ":")
 			host := p[1][2:]
 			port, err := strconv.ParseInt(p[2], 10, 64)
-			client, err := newClient(host, int(port), "fake", "fake", false)
+			client, err := newClient(host, int(port), "fake", "fake", false, 600)
 			_, err = client.call("getdifficulty", nil)
 
 			It("timeout err should occured", func() {


### PR DESCRIPTION
Having a constant timeout isn't that great, especially for longer calls like `GetTxOutsetInfo()`.

This PR makes the http timeout into a variable that can be adjusted.